### PR TITLE
closes #29, "relation ... does not exist", при comment c арг. a_type='T' типа enum 

### DIFF
--- a/15_comment.sql
+++ b/15_comment.sql
@@ -83,6 +83,8 @@ $_$
       RETURN;
     END IF;
 
+    IF v_object = 'TYPE' THEN RETURN; END IF;
+
     -- composite type
     RAISE DEBUG 'READY TO COMMENT COLUMNS';
 

--- a/15_comment.sql
+++ b/15_comment.sql
@@ -34,6 +34,7 @@ $_$
       WHEN a_type = 'v' THEN 'VIEW'
       WHEN a_type = 'c' THEN 'COLUMN'
       WHEN a_type = 'T' THEN 'TYPE'
+      WHEN a_type = 'E' THEN 'TYPE' -- enum type
       WHEN a_type = 'D' THEN 'DOMAIN'
       WHEN a_type = 'f' THEN 'FUNCTION'
       WHEN a_type = 's' THEN 'SEQUENCE'
@@ -79,7 +80,7 @@ $_$
       RAISE DEBUG '%', v_sql;
       EXECUTE v_sql;
     END IF;
-    IF v_object NOT IN ('TABLE', 'VIEW') THEN -- TODO: foreign table
+    IF v_object NOT IN ('TABLE', 'VIEW', 'TYPE') OR a_type = 'E' THEN -- TODO: foreign table
       RETURN;
     END IF;
 

--- a/15_comment.sql
+++ b/15_comment.sql
@@ -79,11 +79,9 @@ $_$
       RAISE DEBUG '%', v_sql;
       EXECUTE v_sql;
     END IF;
-    IF v_object NOT IN ('TABLE', 'VIEW', 'TYPE') THEN -- TODO: foreign table
+    IF v_object NOT IN ('TABLE', 'VIEW') THEN -- TODO: foreign table
       RETURN;
     END IF;
-
-    IF v_object = 'TYPE' THEN RETURN; END IF;
 
     -- composite type
     RAISE DEBUG 'READY TO COMMENT COLUMNS';


### PR DESCRIPTION
исправление ошибки "relation ... does not exist" при вызове comment с a_type=T (TYPE)